### PR TITLE
refactor(debug): Restructure ai-debug module and add completions debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,27 +437,30 @@ AI Mode provides a suite of visual debugging and introspection tools to help you
 
 ### Debugging Commands
 
-These commands, primarily accessed via the `C-c i d` (for `ai-debug-visual`) and `C-c i D` (for `ai-debug-show-sources`) prefixes, open dedicated buffers that use `magit-section-mode` for an interactive, collapsible display of information.
+These commands, primarily accessed via the `C-c i d` prefix, open dedicated buffers that use `magit-section-mode` for an interactive, collapsible display of information.
 
 | Command | Keybinding (default) | Description |
 |---|---|---|
 | `ai-debug-visual` | `C-c i d` | Displays a comprehensive debug view of the *current AI execution context*, including model configuration, buffer context, completion parameters, and the messages being sent to the AI. This is the main entry point for debugging active AI operations. |
-| `ai-debug-show-sources` | `C-c i D` | Displays all *available AI context sources*, such as global system prompts, global memory, buffer-bound prompts, and the temporary context pool. Useful for understanding how different parts of the context are assembled. |
-| `ai-debug-show-file-commands` | `C-c i f` | Displays all *loaded file-based commands* from default, global, and local sources, including their modifiers and content. |
-| `ai-debug-show-system-prompts` | `C-c i s` | Displays all *loaded system prompts* from default, global, and local sources, with their content. |
+| `ai-debug-show-completions` | `C-c i C-c` | Displays current AI completions debug information, including session state, candidates, context settings, command structure, and buffer state for debugging completion behavior. |
 | `ai-debug-show-raw-structures-interactive` | `C-c i R` | Displays all *typed structures in raw sequential format* as they are prepared for the AI model. Useful for understanding the exact order and structure of context elements. |
 | `ai-debug-completion-limited-context` | `C-c i C-d l` | Shows the context specifically for code completion with *limited preceding and following context sizes*. Useful for debugging how completion handles truncated views of your code. |
 | `ai-debug-completion-full-context` | `C-c i C-d f` | Shows the context specifically for code completion using the *entire file content as context*. Useful for debugging full-buffer completion strategies. |
+| `ai-prompt-management-debug-show-cache-status` | `M-x ai-prompt-management-debug-show-cache-status` | Shows the AI prompt management cache debug information, including file-based commands, system prompts, cache statistics, and project information. |
 
 ### Debug Buffer Interaction
 
-Once a debug buffer (e.g., `*AI Debug Context*`, `*AI Context Sources*`) is open, you can interact with it using `magit-section-mode` keybindings:
+Once a debug buffer (e.g., `*AI Debug Context*`, `*AI Completions Debug*`) is open, you can interact with it using `magit-section-mode` keybindings:
 
 | Binding | Command | Description |
 |---|---|---|
 | `TAB` | `magit-section-toggle` | Expand or collapse the section at point. |
 | `C-c t` | `ai-debug-toggle-truncation` | Toggle content truncation within the debug buffer. When enabled, long strings and lists are shortened to improve performance and readability; disable it to see full content. |
 | `C-r` | `ai-debug-refresh-buffer` | Refresh the content of the current debug buffer with the latest AI context information. |
+| `q` | `quit-window` | (In prompt cache debug buffer) Quit the debug window. |
+| `g` | `ai-prompt-management-debug-refresh` | (In prompt cache debug buffer) Refresh the debug buffer. |
+| `u` | `ai-prompt-management-debug-force-update-cache` | (In prompt cache debug buffer) Force update all caches. |
+| `c` | `ai-prompt-management-debug-clear-cache` | (In prompt cache debug buffer) Clear selected cache. |
 
 ## Understanding AI Context
 
@@ -566,7 +569,7 @@ The `ai-mode` package is composed of several `.el` files, each responsible for a
 | `ai-completions.el` | Implements AI-powered code completion, managing suggestion requests, session management, and applying completions. |
 | `ai-context-management.el` | Centralizes the collection, structuring, and storage of context for AI requests, including extended context capabilities and comprehensive context assembly functions. |
 | `ai-core.el` | Serves as the central orchestrator and primary location for fundamental AI-mode logic, coordinating calls between different modules. Includes extended chat functionality. |
-| `ai-debug.el` | Provides visual tools for debugging and introspecting AI states, including prompt composition, execution context, and model configuration. |
+| `ai-debug.el` | Provides visual tools for debugging and introspecting AI states, including prompt composition, execution context, model configuration, and completion session debugging. |
 | `ai-execution.el` | Manages AI request execution and asynchronous interaction with AI backends, handling success and failure callbacks. |
 | `ai-logging.el` | Provides logging utilities for AI mode, including message logging, multi-level verbose control, and structured request/response logging. |
 | `ai-mode-adapter-api.el` | Provides a standardized, type-safe API for `ai-mode` to interact with external AI backends, handling message preparation and content extraction. |
@@ -578,6 +581,7 @@ The `ai-mode` package is composed of several `.el` files, each responsible for a
 | `ai-progress.el` | Manages progress tracking business logic for long-running AI operations, including progress state management, cancellation support, and data structures for tracking AI request progress. |
 | `ai-project.el` | Contains project management utilities for AI mode, including project root detection, file filtering by ignore patterns, and creating project-related data structures. |
 | `ai-prompt-management.el` | Manages the creation, assembly, rendering, and caching of prompts and instructions for AI models. |
+| `ai-prompt-management-debug.el` | Provides debug utilities for the AI prompt management system, including cache inspection, statistics, and interactive debugging tools. |
 | `ai-request-audit.el` | Provides a structured request auditing system for AI mode, including structured storage of request/response data, unique request identification and tracking, and project-based audit organization. |
 | `ai-response-processors.el` | Contains functions for processing and handling responses from AI models, including text extraction, formatting, display, and callback creation for various response insertion and replacement strategies. |
 | `ai-structs.el` | Contains formal definitions of all common data structures (e.g., `typed-struct` and its derived types) used throughout AI-mode. This file is primarily for data structure definitions. |

--- a/ai-mode.el
+++ b/ai-mode.el
@@ -178,6 +178,7 @@
 (require 'ai-mode-indexing)
 (require 'ai-response-processors)
 (require 'ai-core)
+(require 'ai-prompt-management-debug)
 
 (defvar url-http-end-of-headers)
 

--- a/ai-prompt-management-debug.el
+++ b/ai-prompt-management-debug.el
@@ -1,0 +1,289 @@
+;;; ai-prompt-management-debug.el --- Debug utilities for AI prompt management -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 Alex (https://github.com/lispython)
+
+;; This file is part of ai-mode.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; For a full copy of the GNU General Public License
+;; see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; This module provides debug utilities for the AI prompt management system,
+;; including cache inspection, statistics, and interactive debugging tools.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'magit-section)
+(require 'ai-prompt-management)
+(require 'ai-project)
+(require 'ai-logging)
+
+;; Face definitions for consistent styling
+(defface ai-prompt-debug-main-header
+  '((t :inherit magit-section-heading :foreground "brown" :weight bold))
+  "Face for main section headers."
+  :group 'ai-debug)
+
+(defface ai-prompt-debug-category-header
+  '((t :inherit magit-section-heading :foreground "brown"))
+  "Face for category headers."
+  :group 'ai-debug)
+
+(defface ai-prompt-debug-file-header
+  '((t :inherit magit-section-secondary-heading))
+  "Face for file item headers."
+  :group 'ai-debug)
+
+(defface ai-prompt-debug-metadata
+  '((t :inherit magit-dimmed))
+  "Face for metadata information."
+  :group 'ai-debug)
+
+(defface ai-prompt-debug-empty
+  '((t :inherit magit-dimmed :slant italic))
+  "Face for empty or unavailable information."
+  :group 'ai-debug)
+
+(defvar ai-prompt-management-debug-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "q") 'quit-window)
+    (define-key map (kbd "r") 'ai-prompt-management-debug-refresh)
+    (define-key map (kbd "g") 'ai-prompt-management-debug-refresh)
+    (define-key map (kbd "u") 'ai-prompt-management-debug-force-update-cache)
+    (define-key map (kbd "c") 'ai-prompt-management-debug-clear-cache)
+    map)
+  "Keymap for AI prompt management debug mode.")
+
+(define-derived-mode ai-prompt-management-debug-mode magit-section-mode "AI-Debug"
+  "Major mode for debugging AI prompt management caches.
+
+Key bindings:
+\\{ai-prompt-management-debug-mode-map}"
+  :group 'ai
+  (buffer-disable-undo)
+  (setq truncate-lines t)
+  (setq buffer-read-only t))
+
+(defun ai-prompt-management-debug-refresh ()
+  "Refresh the AI prompt management debug buffer."
+  (interactive)
+  (when (eq major-mode 'ai-prompt-management-debug-mode)
+    (ai-prompt-management-debug-show-cache-status)))
+
+(defun ai-prompt-management-debug-force-update-cache ()
+  "Force update all caches and refresh debug buffer."
+  (interactive)
+  (when (eq major-mode 'ai-prompt-management-debug-mode)
+    (ai-prompt-management-force-update-all-caches)
+    (ai-prompt-management-debug-refresh)
+    (message "All caches force updated")))
+
+(defun ai-prompt-management-debug-clear-cache ()
+  "Clear selected cache and refresh debug buffer."
+  (interactive)
+  (when (eq major-mode 'ai-prompt-management-debug-mode)
+    (let ((locations '(("Default" . :default)
+                      ("Global" . :global)
+                      ("Local" . :local))))
+      (when-let* ((selected (completing-read "Clear cache for location: "
+                                           (mapcar #'car locations)))
+                  (location (cdr (assoc selected locations))))
+        (ai-prompt-management-invalidate-cache location)
+        (ai-prompt-management-debug-refresh)
+        (message "Cache cleared for %s" selected)))))
+
+(defun ai-prompt-management-debug--insert-file-section (name file-path index content section-type)
+  "Insert a section for a single file with NAME, FILE-PATH at INDEX with CONTENT and SECTION-TYPE."
+  (let* ((metadata (ai-prompt-management-get-file-metadata file-path))
+         (file-size (when metadata (plist-get metadata :size)))
+         (modified-time (when metadata (plist-get metadata :modification-time)))
+         (metadata-parts '()))
+
+    ;; Build metadata for header - only non-path information
+    (when file-size
+      (push (format "size: %d bytes" file-size) metadata-parts))
+    (when modified-time
+      (push (format "modified: %s" (format-time-string "%Y-%m-%d %H:%M:%S" modified-time)) metadata-parts))
+
+    (magit-insert-section (section-type (format "%d-%s" index name) t) ; Hidden by default
+      (magit-insert-heading
+        ;; Main part: full file path (bold)
+        (propertize file-path 'face 'ai-prompt-debug-file-header)
+        ;; Metadata part: additional attributes (dimmed)
+        (when metadata-parts
+          (concat " " (propertize (format "(%s)" (mapconcat #'identity metadata-parts " | "))
+                                 'face 'ai-prompt-debug-metadata))))
+
+      ;; Insert file content
+      (when content
+        (insert content)
+        (unless (string-suffix-p "\n" content)
+          (insert "\n")))
+      (insert "\n"))))
+
+(defun ai-prompt-management-debug--insert-location-section (location title)
+  "Insert debug section for LOCATION with TITLE."
+  (let* ((cache-info (ai-prompt-management-get-cache-info location))
+         (instruction-count (plist-get cache-info :instruction-count))
+         (system-prompt-count (plist-get cache-info :system-prompt-count))
+         (directory (plist-get cache-info :directory))
+         (directory-exists (plist-get cache-info :directory-exists))
+         (cache-valid (plist-get cache-info :cache-valid))
+         (last-update (plist-get cache-info :last-update))
+         (total-count (+ instruction-count system-prompt-count))
+         (metadata-parts '()))
+
+    ;; Build metadata for header
+    (when directory
+      (push (format "path: %s" directory) metadata-parts))
+    (push (format "exists: %s" (if directory-exists "yes" "no")) metadata-parts)
+    (push (format "valid: %s" (if cache-valid "yes" "no")) metadata-parts)
+    (when last-update
+      (push (format "updated: %s" (format-time-string "%Y-%m-%d %H:%M:%S" last-update)) metadata-parts))
+
+    (magit-insert-section (ai-location location t) ; Hidden by default
+      (magit-insert-heading
+        ;; Main part: cache name and count (bold)
+        (propertize (format "%s Cache (%d items)" (upcase title) total-count)
+                   'face 'ai-prompt-debug-category-header)
+        ;; Metadata part: path and status information (dimmed)
+        (when metadata-parts
+          (concat " " (propertize (format "(%s)" (mapconcat #'identity metadata-parts " | "))
+                                 'face 'ai-prompt-debug-metadata))))
+
+      ;; Instructions section
+      (when (> instruction-count 0)
+        (magit-insert-section (ai-instructions)
+          (magit-insert-heading
+            (propertize (format "Instruction Files (%d items)" instruction-count)
+                       'face 'ai-prompt-debug-file-header))
+          (let ((instruction-files (ai-prompt-management-get-all-instruction-files location))
+                (index 0))
+            (dolist (file-info instruction-files)
+              (let* ((name (car file-info))
+                     (file-path (cdr file-info))
+                     (content (ai-prompt-management--read-file-content file-path)))
+                (ai-prompt-management-debug--insert-file-section name file-path index content 'ai-instruction-file)
+                (setq index (1+ index)))))))
+
+      ;; System prompts section
+      (when (> system-prompt-count 0)
+        (magit-insert-section (ai-system-prompts)
+          (magit-insert-heading
+            (propertize (format "System Prompt Files (%d items)" system-prompt-count)
+                       'face 'ai-prompt-debug-file-header))
+          (let ((system-prompt-names (ai-prompt-management--get-all-system-prompt-names-from-cache
+                                    (cond
+                                     ((eq location :default) 'default)
+                                     ((eq location :global) 'global)
+                                     ((eq location :local) 'local))))
+                (directory-func (cond
+                                ((eq location :default) 'ai-prompt-management--get-default-system-prompts-directory)
+                                ((eq location :global) 'ai-prompt-management--get-global-system-prompts-directory)
+                                ((eq location :local) 'ai-prompt-management--get-local-system-prompts-directory)))
+                (index 0))
+            (when directory-func
+              (let ((system-dir (funcall directory-func)))
+                (dolist (name (sort system-prompt-names #'string<))
+                  (let* ((file-path (ai-prompt-management--get-file-path-for-name name system-dir))
+                         (content (ai-prompt-management--read-file-content file-path)))
+                    (ai-prompt-management-debug--insert-file-section name file-path index content 'ai-system-prompt-file)
+                    (setq index (1+ index)))))))))
+
+      (insert "\n"))))
+
+(defun ai-prompt-management-debug--insert-summary-section ()
+  "Insert summary section with overall statistics."
+  (let* ((default-info (ai-prompt-management-get-cache-info :default))
+         (global-info (ai-prompt-management-get-cache-info :global))
+         (local-info (ai-prompt-management-get-cache-info :local))
+         (total-instructions (+ (plist-get default-info :instruction-count)
+                               (plist-get global-info :instruction-count)
+                               (plist-get local-info :instruction-count)))
+         (total-system-prompts (+ (plist-get default-info :system-prompt-count)
+                                 (plist-get global-info :system-prompt-count)
+                                 (plist-get local-info :system-prompt-count)))
+         (total-items (+ total-instructions total-system-prompts))
+         (project-root (ai-project--get-project-root)))
+
+    (magit-insert-section (ai-summary)
+      (magit-insert-heading
+        (propertize (format "AI Prompt Cache Summary (%d total items)" total-items)
+                   'face 'ai-prompt-debug-category-header))
+
+      (magit-insert-section (ai-project-info)
+        (magit-insert-heading
+          (propertize "Project Information" 'face 'ai-prompt-debug-file-header))
+        (insert (format "    Current Project: %s\n"
+                        (if project-root
+                            (file-name-nondirectory (directory-file-name project-root))
+                          (propertize "No project detected" 'face 'ai-prompt-debug-empty))))
+        (when project-root
+          (insert (format "    Project Root: %s\n" project-root)))
+        (insert "\n"))
+
+      (magit-insert-section (ai-statistics)
+        (magit-insert-heading
+          (propertize "Cache Statistics" 'face 'ai-prompt-debug-file-header))
+        (insert (format "    Total Instructions: %d\n" total-instructions))
+        (insert (format "    Total System Prompts: %d\n" total-system-prompts))
+        (insert (format "    Total Cached Items: %d\n" total-items))
+        (insert "\n"))
+
+      (insert "\n"))))
+
+(defun ai-prompt-management-debug-show-cache-status ()
+  "Show AI prompt management cache status in a dedicated buffer."
+  (interactive)
+  (let* ((buffer-name "*AI Prompt Cache Debug*")
+         (buffer (get-buffer-create buffer-name)))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (ai-prompt-management-debug-mode)
+
+        ;; Set header-line-format with help information
+        (setq header-line-format "AI Prompt Cache Debug - TAB to expand/collapse, r/g to refresh, u to force update, c to clear cache, q to quit")
+
+        ;; Insert root section
+        (magit-insert-section (ai-prompt-debug-root)
+          (magit-insert-heading
+            (propertize "AI Prompt Management Cache Debug" 'face 'ai-prompt-debug-main-header))
+
+          ;; Insert summary section
+          (ai-prompt-management-debug--insert-summary-section)
+
+          ;; Insert location sections
+          (ai-prompt-management-debug--insert-location-section :default "Default")
+          (ai-prompt-management-debug--insert-location-section :global "Global")
+          (ai-prompt-management-debug--insert-location-section :local "Local"))
+
+        ;; Collapse all sections by default
+        (goto-char (point-min))
+        (condition-case-unless-debug nil
+            (let ((root-section (magit-current-section)))
+              (when root-section
+                (dolist (child (oref root-section children))
+                  (magit-section-hide child))))
+          (error nil))
+
+        (goto-char (point-min))))
+
+    ;; Show buffer
+    (pop-to-buffer buffer)))
+
+(provide 'ai-prompt-management-debug)
+
+;;; ai-prompt-management-debug.el ends here


### PR DESCRIPTION
Decompose large ai-debug.el into focused modules by extracting file/system prompt debugging into dedicated ai-prompt-management-debug.el. Add comprehensive AI completions debugging with session state inspection, candidate visualization, and context settings analysis.

- Extract prompt debugging functions to ai-prompt-management-debug.el
- Add ai-debug-show-completions for completion session debugging
- Remove ai-debug-show-sources, ai-debug-show-file-commands, ai-debug-show-system-prompts
- Improve buffer state handling using ai-structs buffer-state objects
- Update context assembly to use command structs instead of string types
- Add completion state collection and visualization functions
- Reorganize debug command keybindings for better UX